### PR TITLE
Incremental creation

### DIFF
--- a/pysheaf.py
+++ b/pysheaf.py
@@ -10,7 +10,6 @@ import random
 import matplotlib.pyplot as plt
 import networkx as nx
 import scipy.optimize
-import copy
 
 ## Data structures
 class Coface: 
@@ -84,11 +83,10 @@ class CellComplex:
         """Add a coface to the cell complex, referenced by a pair of cell names.  The names argument is assumed to be a pair: (face,coface).  The .index attribute for the coface is ignored.  If the cells aren't present, this will raise KeyError."""
         # Look up which cells are involved...
         source=self.cell_dict[names[0]]
-        cf=copy.deepcopy(coface)
-        cf.index=self.cell_dict[names[1]]
+        coface.index=self.cell_dict[names[1]]
 
         # Drop in the coface
-        self.cells[source].cofaces.append(cf)
+        self.cells[source].cofaces.append(coface)
 
     def add_cofaces_from(self,names_list,cofaces):
         for names,coface in zip(names_list,cofaces):

--- a/pysheaf.py
+++ b/pysheaf.py
@@ -93,16 +93,16 @@ class CellComplex:
     def add_coface(self,cellpair,orientation):
         """Add a coface to the cell complex, referenced by a pair of cell names.  The cellpair argument is assumed to be a pair: (face,coface).  If the cells aren't present, this will raise KeyError."""
         # Look up which cells are involved...
-        source=self.cell_dict[names[0]]
-        target=self.cell_dict[names[1]]
+        source=self.cell_dict[cellpair[0]]
+        target=self.cell_dict[cellpair[1]]
 
         # Drop in the coface
         self.coface_dict[(source,coface.index)]=len(self.cells[source].cofaces)
         self.cells[source].cofaces.append(Coface(index=target,orientation=orientation))
 
-    def add_cofaces_from(self,names_list,orientations):
-        for names,orientation in zip(names_list,orientations):
-            self.add_coface(names,orientation)
+    def add_cofaces_from(self,cellpairs,orientations):
+        for cellpair,orientation in zip(cellpairs,orientations):
+            self.add_coface(cellpair,orientation)
         
     def isFaceOf(self,c,cells=None):
         """Construct a list of all cells that a given cell is a face of"""
@@ -502,18 +502,18 @@ class SheafCell(Cell):
 class Sheaf(CellComplex):
 
     def add_coface(self,cellpair,orientation,restriction):
-        """Add a coface to the sheaf, referenced by a pair of cell names.  The cellpair argument is assumed to be a pair: (face,coface).  If the cells aren't present, this will raise KeyError."""
+        """Add a coface to the sheaf, referenced by a pair of cell cellpair.  The cellpair argument is assumed to be a pair: (face,coface).  If the cells aren't present, this will raise KeyError."""
         # Look up which cells are involved...
-        source=self.cell_dict[names[0]]
-        target=self.cell_dict[names[1]]
+        source=self.cell_dict[cellpair[0]]
+        target=self.cell_dict[cellpair[1]]
 
         # Drop in the coface
         self.coface_dict[(source,coface.index)]=len(self.cells[source].cofaces)
         self.cells[source].cofaces.append(SheafCoface(index=target,orientation=orientation,restriction=restriction))
 
-    def add_cofaces_from(self,names_list,orientations,restrictions):
-        for names,orientation,restriction in zip(names_list,orientations,restriction):
-            self.add_coface(names,orientation,restriction)
+    def add_cofaces_from(self,cellpairs,orientations,restrictions):
+        for cellpair,orientation,restriction in zip(cellpairs,orientations,restriction):
+            self.add_coface(cellpair,orientation,restriction)
 
     def isLinear(self):
         """Is this a Sheaf of vector spaces?  (All restrictions are linear maps)"""

--- a/pysheaf.py
+++ b/pysheaf.py
@@ -70,11 +70,15 @@ class CellComplex:
                 for j,cf in enumerate(c.cofaces):
                     self.coface_dict[(i,cf.index)]=j
 
+        # Attribute for counting cells later on...
+        self.cell_counter=len(self.cells)
+        
     def add_cell(self,cell):
         """Add a cell to the cell complex, using the id attribute for registering the cell.  Returns the id attribute for later use"""
 
         if cell.id is None: # Construct an ID if needed
-            cell.id = str(len(self.cells))
+            cell.id = str(self.cell_counter)
+            self.cell_counter += 1
 
         # Register the cell
         self.cell_dict[cell.id]=len(self.cells)
@@ -87,6 +91,7 @@ class CellComplex:
         # Store the cell
         self.cells.append(cell)
 
+        # Return the cell's ID for later use
         return cell.id
 
     def add_cells_from(self,cells):
@@ -100,7 +105,7 @@ class CellComplex:
         target=self.cell_dict[cellpair[1]]
 
         # Drop in the coface
-        self.coface_dict[(source,coface.index)]=len(self.cells[source].cofaces)
+        self.coface_dict[(source,target)]=len(self.cells[source].cofaces)
         self.cells[source].cofaces.append(Coface(index=target,orientation=orientation))
 
     def add_cofaces_from(self,cellpairs,orientations):
@@ -511,7 +516,7 @@ class Sheaf(CellComplex):
         target=self.cell_dict[cellpair[1]]
 
         # Drop in the coface
-        self.coface_dict[(source,coface.index)]=len(self.cells[source].cofaces)
+        self.coface_dict[(source,target)]=len(self.cells[source].cofaces)
         self.cells[source].cofaces.append(SheafCoface(index=target,orientation=orientation,restriction=restriction))
 
     def add_cofaces_from(self,cellpairs,orientations,restrictions):

--- a/pysheaf.py
+++ b/pysheaf.py
@@ -65,6 +65,9 @@ class CellComplex:
             if c.name == None: # Build names if not present
                 c.name = str(i)
             self.cell_dict[c.name]=i
+            if c.cofaces is not None: # Register cofaces if present
+                for j,cf in enumerate(c.cofaces):
+                    self.coface_dict[(i,cf.index)]=j
 
     def add_cell(self,cell):
         """Add a cell to the cell complex"""
@@ -72,7 +75,15 @@ class CellComplex:
         if cell.name == None: # Construct a name if needed
             cell.name = str(len(self.cells))
 
+        # Register the cell
         self.cell_dict[cell.name]=len(self.cells)
+
+        # Register its cofaces, if any
+        if cell.cofaces is not None:
+            for j,cf in enumerate(cell.cofaces):
+                self.coface_dict[(len(self.cells),cf.index)]=j
+
+        # Store the cell
         self.cells.append(cell)
 
     def add_cells_from(self,cells):
@@ -86,6 +97,7 @@ class CellComplex:
         coface.index=self.cell_dict[names[1]]
 
         # Drop in the coface
+        self.coface_dict[(source,coface.index)]=len(self.cells[source].cofaces)
         self.cells[source].cofaces.append(coface)
 
     def add_cofaces_from(self,names_list,cofaces):

--- a/pysheaf.py
+++ b/pysheaf.py
@@ -26,7 +26,7 @@ class Cell:
     def __init__(self,dimension,compactClosure=True,cofaces=None, name=None):
         self.dimension=dimension
         self.compactClosure=compactClosure
-        if cofaces != None:
+        if cofaces is not None:
             self.cofaces = cofaces
         else:
             self.cofaces = []
@@ -53,7 +53,7 @@ class Cell:
 class CellComplex:
     def __init__(self,cells=None):
         """Construct a cell complex from its cells"""
-        if cells == None:
+        if cells is None:
             self.cells=[]
         else:
             self.cells=cells
@@ -62,7 +62,7 @@ class CellComplex:
         self.cell_dict={}
         self.coface_dict={}
         for i,c in enumerate(self.cells):
-            if c.name == None: # Build names if not present
+            if c.name is None: # Build names if not present
                 c.name = str(i)
             self.cell_dict[c.name]=i
             if c.cofaces is not None: # Register cofaces if present
@@ -72,7 +72,7 @@ class CellComplex:
     def add_cell(self,cell):
         """Add a cell to the cell complex"""
 
-        if cell.name == None: # Construct a name if needed
+        if cell.name is None: # Construct a name if needed
             cell.name = str(len(self.cells))
 
         # Register the cell
@@ -383,7 +383,7 @@ class AbstractSimplicialComplex(CellComplex):
         Beware: this should not be constructed for complexes involving high-dimensional simplices!
         Simplices are sorted from greatest dimension to least"""
         
-        if maxdim == None:
+        if maxdim is None:
             maxdim=max([len(tplx)-1 for tplx in toplexes])
             
         self.cells=[]
@@ -455,7 +455,7 @@ class SheafCell(Cell):
     cofaces = list of SheafCoface instances, one for each coface of this cell
     stalkDim = dimension of the stalk over this cell (defaults to figuring it out from the cofaces if the restriction is a LinearMorphism) or None if stalk is not a real vector space"""
     def __init__(self,dimension,cofaces=None,compactClosure=True,stalkDim=None,metric=None,name=None):
-        if stalkDim == None and cofaces:
+        if stalkDim is None and cofaces:
             if cofaces[0].isLinear():
                 try:  # Try to discern the stalk dimension from the matrix representation. This will fail if the matrix isn't given
                     self.stalkDim=cofaces[0].restriction.matrix.shape[1]
@@ -466,7 +466,7 @@ class SheafCell(Cell):
         else:
             self.stalkDim=stalkDim
 
-        if metric != None:
+        if metric is not None:
             self.metric=metric
         else:
             self.metric=lambda x,y: np.linalg.norm(x-y)
@@ -475,7 +475,7 @@ class SheafCell(Cell):
 
     def isLinear(self):
         """Is this cell representative of a Sheaf of vector spaces?  (All restrictions are linear maps)"""
-        if self.stalkDim == None:
+        if self.stalkDim is None:
             return False
         for cf in self.cofaces:
             if not cf.isLinear():
@@ -484,7 +484,7 @@ class SheafCell(Cell):
 
     def isNumeric(self):
         """Is this cell representative of a sheaf of sets in which stalks are all real vector spaces? (restrictions may not be linear maps, though)"""
-        if self.stalkDim == None:
+        if self.stalkDim is None:
             return False
         else:
             return True
@@ -966,9 +966,9 @@ class DirectedGraph(CellComplex):
         for ed in graph:
             s=ed[0]
             d=ed[1]
-            if s != None:
+            if s is not None:
                 verts.append(s)
-            if d != None:
+            if d is not None:
                 verts.append(d)
         verts=list(set(verts))
 
@@ -1475,6 +1475,6 @@ def ksimplices(toplexes,k,relative=None):
     simplices=[]
     for toplex in toplexes:
         for spx in ksublists(toplex,k+1):
-            if not spx in simplices and (relative == None or not spx in relative):
+            if not spx in simplices and (relative is None or not spx in relative):
                 simplices.append(spx)
     return simplices 

--- a/pysheaf.py
+++ b/pysheaf.py
@@ -90,19 +90,19 @@ class CellComplex:
         for c in cells:
             self.add_cell(c)
 
-    def add_coface(self,names,coface):
-        """Add a coface to the cell complex, referenced by a pair of cell names.  The names argument is assumed to be a pair: (face,coface).  The .index attribute for the coface is ignored.  If the cells aren't present, this will raise KeyError."""
+    def add_coface(self,cellpair,orientation):
+        """Add a coface to the cell complex, referenced by a pair of cell names.  The cellpair argument is assumed to be a pair: (face,coface).  If the cells aren't present, this will raise KeyError."""
         # Look up which cells are involved...
         source=self.cell_dict[names[0]]
-        coface.index=self.cell_dict[names[1]]
+        target=self.cell_dict[names[1]]
 
         # Drop in the coface
         self.coface_dict[(source,coface.index)]=len(self.cells[source].cofaces)
-        self.cells[source].cofaces.append(coface)
+        self.cells[source].cofaces.append(Coface(index=target,orientation=orientation))
 
-    def add_cofaces_from(self,names_list,cofaces):
-        for names,coface in zip(names_list,cofaces):
-            self.add_coface(names,coface)
+    def add_cofaces_from(self,names_list,orientations):
+        for names,orientation in zip(names_list,orientations):
+            self.add_coface(names,orientation)
         
     def isFaceOf(self,c,cells=None):
         """Construct a list of all cells that a given cell is a face of"""
@@ -500,6 +500,20 @@ class SheafCell(Cell):
 
 # Sheaf class
 class Sheaf(CellComplex):
+
+    def add_coface(self,cellpair,orientation,restriction):
+        """Add a coface to the sheaf, referenced by a pair of cell names.  The cellpair argument is assumed to be a pair: (face,coface).  If the cells aren't present, this will raise KeyError."""
+        # Look up which cells are involved...
+        source=self.cell_dict[names[0]]
+        target=self.cell_dict[names[1]]
+
+        # Drop in the coface
+        self.coface_dict[(source,coface.index)]=len(self.cells[source].cofaces)
+        self.cells[source].cofaces.append(SheafCoface(index=target,orientation=orientation,restriction=restriction))
+
+    def add_cofaces_from(self,names_list,orientations,restrictions):
+        for names,orientation,restriction in zip(names_list,orientations,restriction):
+            self.add_coface(names,orientation,restriction)
 
     def isLinear(self):
         """Is this a Sheaf of vector spaces?  (All restrictions are linear maps)"""

--- a/tests/incremental_test.py
+++ b/tests/incremental_test.py
@@ -1,0 +1,28 @@
+# Unit test for incremental cell creation in PySheaf
+#
+# Copyright (c) 2017, Michael Robinson
+# Distribution of unaltered copies permitted for noncommercial use only
+# All other uses require express permission of the author
+# This software comes with no warrantees express or implied 
+
+import pysheaf as ps
+import numpy as np
+
+# Create some cells
+cA=ps.SheafCell(name='A',dimension=0,stalkDim=2)
+cB=ps.SheafCell(name='B',dimension=0,stalkDim=2)
+cAB=ps.SheafCell(name='AB',dimension=1,stalkDim=2)
+
+# Initialize the sheaf structure
+s=ps.Sheaf()
+
+# Add two cells, remembering their IDs assigned by the Sheaf
+cA_id=s.add_cell(cA)
+cAB_id=s.add_cell(cAB)
+
+# Add a coface
+s.add_coface((cA_id,cAB_id),orientation=1,restriction=np.array([[1,0],[0,1]]))
+
+# Add another cell and coface
+cB_id=s.add_cell(cB)
+s.add_coface((cB_id,cAB_id),orientation=1,restriction=np.array([[0,1],[1,0]]))


### PR DESCRIPTION
A lot of things have changed, admittedly, but pysheaf should now support both the create-everything-at-once idiom embodied in the existing tests/ directory and an incremental creation of CellComplexes and derived classes.  For instance, you can now do

>>> s=ps.Sheaf()
>>> s.add_cell(ps.SheafCell(0,name='A'))
>>> s.add_cell(ps.SheafCell(1,name='AB'))
>>> s.add_coface(('A','AB'),ps.SheafCoface(restriction=ps.LinearMorphism([-1])))
>>> s.add_cell(ps.SheafCell(0,name='B'))
>>> s.add_coface(('B','AB'),ps.SheafCoface(restriction=ps.LinearMorphism([1])))

As a result, I had to tweak constructors for Coface and SheafCoface to make the .index attribute optional, so that explains a fair bit of the changes as well.
